### PR TITLE
Use type-forwarding to avoid conditional references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,6 @@ The package is available [on NuGet](https://www.nuget.org/packages/IndexRange). 
 dotnet add package IndexRange --version 1.0.0-beta3
 ```
 
-Note: this package should _only_ be installed in projects targeting .NET Framework (e.g., `net48`) or `netstandard2.0`. If you're multi-targeting, manually edit
-your csproj XML to install the package conditionally, e.g.,
-
-```xml
-<PackageReference Include="IndexRange" Version="1.0.0-beta3" Condition=" '$(TargetFramework)' == 'netstandard2.0' " />
-```
-
 ## Build Status
 
 [![Build Status](https://dev.azure.com/bgrainger/Public/_apis/build/status/bgrainger.IndexRange?branchName=master)](https://dev.azure.com/bgrainger/Public/_build/latest?definitionId=3&branchName=master)

--- a/src/IndexRange/Index.cs
+++ b/src/IndexRange/Index.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.CompilerServices;
 
+#if NETSTANDARD2_0
 namespace System
 {
     /// <summary>Represent a type can be used to index a collection either from the start or the end.</summary>
@@ -138,3 +139,6 @@ namespace System
         }
     }
 }
+#else
+[assembly:TypeForwardedToAttribute(typeof(System.Index))]  
+#endif

--- a/src/IndexRange/IndexRange.csproj
+++ b/src/IndexRange/IndexRange.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.0.0</VersionPrefix>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>Enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/IndexRange/Range.cs
+++ b/src/IndexRange/Range.cs
@@ -4,6 +4,7 @@
 
 using System.Runtime.CompilerServices;
 
+#if NETSTANDARD2_0
 namespace System
 {
     /// <summary>Represent a range has start and end indexes.</summary>
@@ -97,3 +98,6 @@ namespace System
         }
     }
 }
+#else
+[assembly:TypeForwardedToAttribute(typeof(System.Range))]  
+#endif

--- a/tests/IndexRange.UnitTests/IndexRange.UnitTests.csproj
+++ b/tests/IndexRange.UnitTests/IndexRange.UnitTests.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net48' or '$(TargetFramework)' == 'netcoreapp2.0'  ">
-    <ProjectReference Include="..\..\src\IndexRange\IndexRange.csproj" />
     <PackageReference Include="System.Memory" Version="4.5.3" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\src\IndexRange\IndexRange.csproj" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />


### PR DESCRIPTION
This allows consumers who are multi-targeting to safely consume this package on `netstandard2.1` or `netcoreapp3.0`.