### PR TITLE
fix: upgrade `Microsoft.Bcl.Memory` to `9.0.14` due to vulnerability

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,8 @@
 # Version History
 
+### 1.1.1
+* Update `Microsoft.Bcl.Memory` to `9.0.14` to address [vulnerability](https://github.com/advisories/GHSA-73j8-2gch-69rq)
+
 ### 1.0.2
 
 * Mark assembly as CLS compliant.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 jobs:
 - job: Windows
   pool:
-    vmImage: 'windows-latest'
+    vmImage: 'windows-2022'
   steps:
   - template: '.ci/azure-build.yml'

--- a/src/IndexRange/IndexRange.csproj
+++ b/src/IndexRange/IndexRange.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.1.1</VersionPrefix>
     <TargetFrameworks>net35;net45;net462;net47;netstandard2.0;netstandard2.1;uap10.0</TargetFrameworks>
     <TargetPlatformMinVersion Condition=" '$(TargetFramework)' == 'uap10.0' ">10.0.10240.0</TargetPlatformMinVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
@@ -55,7 +55,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'net462' or '$(TargetFramework)' == 'net47' ">
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.14" />
   </ItemGroup>
 
 </Project>

--- a/src/IndexRange/IndexRange.csproj
+++ b/src/IndexRange/IndexRange.csproj
@@ -13,11 +13,11 @@
     <AssemblyOriginatorKeyFile>..\..\IndexRange.snk</AssemblyOriginatorKeyFile>
     <Title>System.Index and System.Range</Title>
     <Description>Implementations of System.Index and System.Range for netstandard2.0 and .NET Framework.</Description>
-    <Copyright>Copyright 2019–2025 Bradley Grainger</Copyright>
+    <Copyright>Copyright 2019–2026 Bradley Grainger</Copyright>
     <Authors>Bradley Grainger</Authors>
     <PackageTags>Index;System.Index;Range;System.Range;C#8</PackageTags>
     <PackageProjectUrl>https://github.com/bgrainger/IndexRange</PackageProjectUrl>
-    <PackageReleaseNotes>* Type-forward implementations to Microsoft.Bcl.Memory for netstandard2.0, net462, and higher.</PackageReleaseNotes>
+    <PackageReleaseNotes>* Update Microsoft.Bcl.Memory to 9.0.14 for CVE-2026-26127.</PackageReleaseNotes>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIconUrl>https://raw.githubusercontent.com/bgrainger/IndexRange/master/icon.png</PackageIconUrl>
     <PackageIcon>icon.png</PackageIcon>


### PR DESCRIPTION
I know the repo is listed as unsupported but figured I'd make the PR here just in case you were open to still publishing a new version for something like this

Background on the vulnerability
https://github.com/advisories/GHSA-73j8-2gch-69rq

Closes #17 